### PR TITLE
Replace IP based allowlist with psk based

### DIFF
--- a/integration-test/src/fixtures/localServer.config.ts
+++ b/integration-test/src/fixtures/localServer.config.ts
@@ -6,16 +6,26 @@ export const ENV = {
   },
   auth: {
     PORT: '3000',
-    ALLOWLIST: 'localhost:local:superadmin',
+    ALLOWLIST: [
+      'superadmin:local:superadmin',
+      'authservice:local:authservice',
+      'deviceservice:local:deviceservice',
+      'experimentservice:local:experimentservice',
+      'federationservice:local:federationservice',
+    ].join(','),
+    API_TOKEN: 'authservice',
   },
   device: {
     PORT: '3001',
+    API_TOKEN: 'deviceservice',
   },
   experiment: {
     PORT: '3002',
+    API_TOKEN: 'experimentservice',
   },
   federation: {
     PORT: '3003',
+    API_TOKEN: 'federationservice',
   },
   gateway: {
     AUTH_SERVICE_URL: '127.0.0.1:3000',

--- a/services/auth/src/config.ts
+++ b/services/auth/src/config.ts
@@ -27,6 +27,7 @@ function initializeAppConfiguration(): AppConfiguration {
             process.env.SECURITY_AUDIENCE ??
             die('the environment variable SECURITY_AUDIENCE is not defined!'),
         ALLOWLIST: process.env.ALLOWLIST ?? '',
+        API_TOKEN: process.env.API_TOKEN ?? '',
     }
 }
 

--- a/services/auth/src/database/dataSource.ts
+++ b/services/auth/src/database/dataSource.ts
@@ -68,7 +68,7 @@ const scopesStandardRolesMapping: ScopeRecord = {
     'device:connect:current': ['device'],
     'device:signal': ['device_service'],
     'peerconnection': ['developer', 'experiment_service'],
-    'peerconnection:read': [],
+    'peerconnection:read': ['device_service'],
     'peerconnection:create': [],
     'peerconnection:delete': [],
     // experiment service scopes

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -3,6 +3,7 @@ import { AppDataSource, initializeDataSource } from './database/dataSource'
 import { activeKeyRepository } from './database/repositories/activeKeyRepository'
 import { app } from './generated'
 import { parseAllowlist, resolveAllowlist } from './methods/allowlist'
+import { apiClient } from './methods/api'
 import { generateNewKey, jwk } from './methods/key'
 import { AppConfiguration } from './types/types'
 import { JWTVerify } from '@crosslab/service-common'
@@ -15,6 +16,7 @@ async function startAuthenticationService(
     await AppDataSource.initialize(options)
     await initializeDataSource()
 
+    apiClient.accessToken = appConfig.API_TOKEN
     const allowlist = appConfig.ALLOWLIST ? parseAllowlist(appConfig.ALLOWLIST) : []
 
     // Resolve Allowlist

--- a/services/auth/src/types/types.ts
+++ b/services/auth/src/types/types.ts
@@ -48,7 +48,7 @@ export type ActiveKey<T extends 'request' | 'response' | 'all' = 'all'> = T exte
     : never
 
 export type AllowlistEntry = {
-    url: string
+    token: string
     username: string
 }
 
@@ -59,4 +59,5 @@ export type AppConfiguration = {
     SECURITY_ISSUER: string
     SECURITY_AUDIENCE: string
     ALLOWLIST: string
+    API_TOKEN: string
 }

--- a/services/auth/test/methods/allowlist.spec.ts
+++ b/services/auth/test/methods/allowlist.spec.ts
@@ -28,8 +28,8 @@ export default () =>
                     const expectedLength = (validAllowlist.match(/,/g) ?? []).length + 1
                     assert(parsedAllowlist.length === expectedLength)
                     for (const entry of parsedAllowlist) {
-                        assert(entry.url === 'url')
-                        assert(entry.url === 'username')
+                        assert(entry.token === 'url')
+                        assert(entry.token === 'username')
                     }
                 }
             })
@@ -73,7 +73,7 @@ export default () =>
                 USERNAME = 'username'
                 ALLOWLIST = [
                     {
-                        url: URL,
+                        token: URL,
                         username: USERNAME,
                     },
                 ]
@@ -99,16 +99,6 @@ export default () =>
                 assert(allowlist[IP] === USERNAME)
             })
 
-            it('should log an error if the ip could not be resolved', async function () {
-                const NEW_ALLOWLIST = JSON.parse(JSON.stringify(ALLOWLIST))
-                NEW_ALLOWLIST[0].url = '...'
-
-                await resolveAllowlist(NEW_ALLOWLIST)
-
-                const lastCall = consoleErrorStub.getCalls().reverse()[0]
-                assert(lastCall.args[0] instanceof DNSResolveError)
-            })
-
             it('should log an error if the user could not be found', async function () {
                 findUserStub.returns(Promise.resolve(null))
 
@@ -132,7 +122,7 @@ export default () =>
                 IP = '127.0.0.1'
                 USERNAME = 'username'
                 ALLOWLIST_ENTRY = {
-                    url: URL,
+                    token: URL,
                     username: USERNAME,
                 }
             })
@@ -158,7 +148,7 @@ export default () =>
 
             it('should log an error if the DNS lookup fails', async function () {
                 const INVALID_ALLOWLIST_ENTRY: AllowlistEntry = {
-                    url: '...',
+                    token: '...',
                     username: USERNAME,
                 }
 

--- a/services/auth/test/operations/auth/get.spec.ts
+++ b/services/auth/test/operations/auth/get.spec.ts
@@ -105,14 +105,14 @@ export default function (context: Mocha.Context, testData: TestData) {
     let invalidToken: string
     let validDeviceToken: string
     let validUserToken: string
-    let allowlistedIP: string
+    let allowlistedToken: string
 
     suite.beforeAll(function () {
         expiredToken = testData.tokens['GET /auth expired token'].model.token
         invalidToken = 'invalid'
         validDeviceToken = testData.tokens['GET /auth valid device token'].model.token
         validUserToken = testData.tokens['GET /auth valid user token'].model.token
-        allowlistedIP = '127.0.0.1'
+        allowlistedToken = 'localhost'
     })
 
     suite.addTest(
@@ -127,6 +127,23 @@ export default function (context: Mocha.Context, testData: TestData) {
                 await checkJWTByTokenModel(
                     result.headers.Authorization,
                     testData.tokens['GET /auth valid user token'].model
+                )
+            }
+        )
+    )
+
+    suite.addTest(
+        new Mocha.Test(
+            'should authenticate an allowlisted user with a valid token',
+            async function () {
+                const result = await getAuth({
+                    Authorization: `Bearer ${allowlistedToken}`,
+                })
+                assert(result.status === 200)
+                assert(result.headers.Authorization)
+                await checkJWTByUserModel(
+                    result.headers.Authorization,
+                    testData.users.superadmin.model
                 )
             }
         )
@@ -216,77 +233,6 @@ export default function (context: Mocha.Context, testData: TestData) {
                     assert(error instanceof MissingEntityError)
                     assert(error.status === 401)
                 }
-            }
-        )
-    )
-
-    suite.addTest(
-        new Mocha.Test(
-            "should authenticate an allowlisted user without an 'Authorization'-header",
-            async function () {
-                const result = await getAuth({
-                    'X-Real-IP': allowlistedIP,
-                })
-                assert(result.status === 200)
-                assert(result.headers.Authorization)
-                await checkJWTByUserModel(
-                    result.headers.Authorization,
-                    testData.users.superadmin.model
-                )
-            }
-        )
-    )
-
-    suite.addTest(
-        new Mocha.Test(
-            'should authenticate the user associated with the provided valid token instead of the allowlisted user',
-            async function () {
-                const result = await getAuth({
-                    'Authorization': `Bearer ${validUserToken}`,
-                    'X-Real-IP': allowlistedIP,
-                })
-                assert(result.status === 200)
-                assert(result.headers.Authorization)
-                await checkJWTByTokenModel(
-                    result.headers.Authorization,
-                    testData.tokens['GET /auth valid user token'].model
-                )
-            }
-        )
-    )
-
-    suite.addTest(
-        new Mocha.Test(
-            'should authenticate the allowlisted user even if the provided token is invalid',
-            async function () {
-                const result = await getAuth({
-                    'Authorization': `Bearer ${invalidToken}`,
-                    'X-Real-IP': allowlistedIP,
-                })
-                assert(result.status === 200)
-                assert(result.headers.Authorization)
-                await checkJWTByUserModel(
-                    result.headers.Authorization,
-                    testData.users.superadmin.model
-                )
-            }
-        )
-    )
-
-    suite.addTest(
-        new Mocha.Test(
-            'should authenticate the allowlisted user even if the provided token is expired',
-            async function () {
-                const result = await getAuth({
-                    'Authorization': `Bearer ${expiredToken}`,
-                    'X-Real-IP': allowlistedIP,
-                })
-                assert(result.status === 200)
-                assert(result.headers.Authorization)
-                await checkJWTByUserModel(
-                    result.headers.Authorization,
-                    testData.users.superadmin.model
-                )
             }
         )
     )

--- a/services/device/src/config.ts
+++ b/services/device/src/config.ts
@@ -16,6 +16,7 @@ export type AppConfiguration = {
     BASE_URL: string
     SECURITY_ISSUER: string
     SECURITY_AUDIENCE: string
+    API_TOKEN: string
 }
 
 function die(reason: string): string {
@@ -37,6 +38,7 @@ function initializeAppConfiguration(): AppConfiguration {
         SECURITY_AUDIENCE:
             process.env.SECURITY_AUDIENCE ??
             die('the environment variable SECURITY_AUDIENCE is not defined!'),
+        API_TOKEN: process.env.API_TOKEN ?? '',
     }
 }
 

--- a/services/device/src/index.ts
+++ b/services/device/src/index.ts
@@ -2,6 +2,7 @@
 import { config, dataSourceConfig } from './config'
 import { AppDataSource } from './database/dataSource'
 import { app } from './generated/index'
+import { apiClient } from './globals'
 import { callbackHandling } from './operations/callbacks'
 import { websocketHandling } from './operations/devices'
 import { JWTVerify } from '@crosslab/service-common'
@@ -21,6 +22,8 @@ declare global {
 
 async function startDeviceService() {
     await AppDataSource.initialize(dataSourceConfig)
+
+    apiClient.accessToken = config.API_TOKEN
 
     app.use((req, _res, next) => {
         for (const param in req.query) {

--- a/services/experiment/src/config.ts
+++ b/services/experiment/src/config.ts
@@ -15,4 +15,5 @@ export const config = {
     SECURITY_AUDIENCE:
         process.env.SECURITY_AUDIENCE ??
         die('the environment variable SECURITY_AUDIENCE is not define!'),
+    API_TOKEN: process.env.API_TOKEN ?? '',
 }

--- a/services/experiment/src/index.ts
+++ b/services/experiment/src/index.ts
@@ -1,50 +1,54 @@
 #!/usr/bin/env node
-
 import { config } from './config'
 import { AppDataSource } from './database/data_source'
 import { app } from './generated/index'
+import { apiClient } from './util/api'
 import { callbackHandling } from './util/callbacks'
-import expressWinston from 'express-winston'
 import { logger } from './util/requestHandler'
 import { JWTVerify } from '@crosslab/service-common'
+import expressWinston from 'express-winston'
 
 AppDataSource.initialize()
     .then(() => {
-        app.use(expressWinston.logger({
-            winstonInstance: logger,
-            // optional: control whether you want to log the meta data about the request (default to true)
-            meta: true,
-            // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
-            msg: "HTTP {{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}",
-            // Use the default Express/morgan request formatting. Enabling this will override any msg if true.
-            // Will only output colors with colorize set to true
-            expressFormat: true,
-            // Color the text and status code, using the Express/morgan color palette
-            // (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
-            colorize: false,
-            // optional: allows to skip some log messages based on request and/or response
-            ignoreRoute: function (_req, _res) { return false; },
-            requestFilter: (req, propName) => {
-                if (propName === "headers" && req.headers.authorization)
-                    return {
-                        ...req.headers,
-                        authorization: "HIDDEN"
-                    }
-                return req[propName]
-            }
-        }));
+        apiClient.accessToken = config.API_TOKEN
+
+        app.use(
+            expressWinston.logger({
+                winstonInstance: logger,
+                // optional: control whether you want to log the meta data about the request (default to true)
+                meta: true,
+                // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
+                msg: 'HTTP {{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}',
+                // Use the default Express/morgan request formatting. Enabling this will override any msg if true.
+                // Will only output colors with colorize set to true
+                expressFormat: true,
+                // Color the text and status code, using the Express/morgan color palette
+                // (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
+                colorize: false,
+                // optional: allows to skip some log messages based on request and/or response
+                ignoreRoute: function (_req, _res) {
+                    return false
+                },
+                requestFilter: (req, propName) => {
+                    if (propName === 'headers' && req.headers.authorization)
+                        return {
+                            ...req.headers,
+                            authorization: 'HIDDEN',
+                        }
+                    return req[propName]
+                },
+            })
+        )
 
         app.get('/experiment/status', (_req, res) => {
             res.send({ status: 'ok' })
-        });
+        })
 
         app.initService({
-            security: { 
-                "JWT": JWTVerify(config) as any
+            security: {
+                JWT: JWTVerify(config) as any,
             },
-            additionalHandlers: [
-                callbackHandling
-            ]
+            additionalHandlers: [callbackHandling],
         })
         app.listen(config.PORT)
     })

--- a/services/experiment/src/util/api.ts
+++ b/services/experiment/src/util/api.ts
@@ -1,3 +1,6 @@
+import { config } from '../config'
+import { InternalRequestError, MissingPropertyError } from '../types/errors'
+import { RequestHandler } from './requestHandler'
 import {
     ValidationError,
     InvalidUrlError,
@@ -7,11 +10,8 @@ import {
     DeviceServiceTypes,
 } from '@cross-lab-project/api-client'
 import fetch from 'node-fetch'
-import { config } from '../config'
-import { InternalRequestError, MissingPropertyError } from '../types/errors'
-import { RequestHandler } from './requestHandler'
 
-const apiClient: APIClient = new APIClient(config.BASE_URL)
+export const apiClient: APIClient = new APIClient(config.BASE_URL)
 
 /**
  * TODO: add more information on request/response
@@ -279,7 +279,7 @@ export async function unlockDevices(
  * @param args The arguments of the getPeerconnection() function.
  * @throws {InternalRequestError} Thrown if an error occurs during the request.
  */
- export async function getPeerconnection(
+export async function getPeerconnection(
     requestHandler: RequestHandler,
     ...args: Parameters<typeof apiClient.getPeerconnection>
 ) {


### PR DESCRIPTION
SInce the default scopes needed to be adapted, they will also need to be adapted in the database. Furthermore the API_TOKEN environment variables will need to be set for the deployment and the allowlist needs to be updated accordingly. A simple example can be found in `integration-test/src/fixtures/localServer.config.ts`.