### PR TITLE
fix ldap authentication bug

### DIFF
--- a/services/auth/src/authenticationSources/ldap.ts
+++ b/services/auth/src/authenticationSources/ldap.ts
@@ -45,7 +45,7 @@ export class LdapAuthenticationSource implements AuthenticationSource {
    */
   private async ldap_bind(username: string, password: string): Promise<boolean> {
     // Initialize Ldap Client
-    if (!this.config.url) {
+    if (!this.config.url || !password) {
       return false;
     }
     const client = new ldapts.Client({


### PR DESCRIPTION
This should fix a bug that makes it possible to log in as an ldap user without the correct password.